### PR TITLE
Containerize app deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ WORKDIR /opt/src
 # - numpy==1.14.3 because it's a magic version based on some "how to install
 # pandas in alpine" threads around the internet
 # - webob because it's required but was missing
+# Dependency installs are separated because some of them take _way longer_
+# than others (pandas, numpy)
+
+# System deps
 RUN apk update \
     && apk add \
         build-base \
@@ -25,19 +29,24 @@ RUN apk update \
         postgresql-dev \
         libffi-dev \
         musl-dev \
-    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
-    && pip install \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h
+
+# super painful python deps
+RUN pip install \
+      shapely \
+      pyproj==1.9.3 \
+      numpy==1.14.3 \
+      geopandas==0.6.3
+
+# less painful python deps
+RUN pip install \
       uwsgi \
-      sqlalchemy==1.1.9 \
+      sqlalchemy==1.3.0 \
       Flask-User==0.6.19 \
       Flask-Migrate \
       Flask-Script \
       psycopg2-binary \
       PyGithub==1.35 \
-      shapely \
-      pyproj==1.9.3 \
-      numpy==1.14.3 \
-      geopandas==0.6.3 \
       webob==1.8.7
 
 COPY ./api/*.wsgi /opt/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM osgeo/gdal:alpine-normal-v2.4.1
+
+RUN mkdir -p /opt/src
+
+WORKDIR /opt/src
+
+# Pins that aren't part of the setup doc are:
+# - sqlalchemy==1.1.9 to ensure we don't pull a py3 syntax SQLAlchemy
+# - geopandas==0.6.1 to get to a low enough pyproj pin to work with our gdal universe deps
+# - pyproj==1.9.3 because geopandas expresses >= 1.9.3 and there are lots of more recent versions
+# - numpy==1.14.3 because it's a magic version based on some "how to install
+# pandas in alpine" threads around the internet
+# - webob because it's required but was missing
+RUN apk update \
+    && apk add \
+        build-base \
+        gfortran \
+        python2 \
+        python2-dev \
+        py-pip \
+        R \
+        gcc \
+        libc-dev \
+        linux-headers \
+        postgresql-dev \
+        libffi-dev \
+        musl-dev \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
+    && pip install \
+      uwsgi \
+      sqlalchemy==1.1.9 \
+      Flask-User==0.6.19 \
+      Flask-Migrate \
+      Flask-Script \
+      psycopg2-binary \
+      PyGithub==1.35 \
+      shapely \
+      pyproj==1.9.3 \
+      numpy==1.14.3 \
+      geopandas==0.6.3 \
+      webob==1.8.7
+
+COPY ./api/*.wsgi /opt/src/
+COPY ./common/webapp /opt/src/webapp
+COPY ./common/create_hit_daemon.py /opt/src/daemon/
+
+ENTRYPOINT ["uwsgi"]

--- a/api/genkml.wsgi
+++ b/api/genkml.wsgi
@@ -3,7 +3,7 @@ import sys
 from datetime import datetime
 from webob import Request, Response
 from webob.response import ResponseBodyFile
-from MappingCommon import MappingCommon
+from webapp.MappingCommon import MappingCommon
 
 def application(environ, start_response):
     req = Request(environ)

--- a/api/getkml.wsgi
+++ b/api/getkml.wsgi
@@ -1,6 +1,6 @@
 from webob import Request, Response
 import datetime
-from MappingCommon import MappingCommon
+from webapp.MappingCommon import MappingCommon
 
 def application(environ, start_response):
     req = Request(environ)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2.3"
+services:
+  application:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: agroimpacts/labeller
+    ports:
+      - 9090:9090
+    command:
+      - --http
+      - :9090
+      - --wsgi-file
+      - "getkml.wsgi"


### PR DESCRIPTION
This PR adds a Dockerfile for running the various wsgi applications and a single docker-compose service that runs one of them. In this PR I'll also include notes from my conversation with @ldemaz yesterday explaining the application layout and what's required.

It's _pretty close_ to having a running application, but dependency hell is real so there's a lot of tweaking versions of things based on specific error messages, and everything is old, so any constraint expressed as `>= x.y.z` in any dep is pulling in something far too new, sometimes with python3 syntax because dependency management and publication is hard to get right.

## Notes from call

- document explaining the configuration of the EC2 instance is `docs/build-labeller.md` in the repo (e.g. https://github.com/jisantuc/labeller/blob/feature/js/run-as-container/docs/build-labeller.md)
- there are a few daemons mentioned in the `mapper_design.md` file (`mapper` is the previuos name of `labeller`). the only one of those that you _must_ have running is `create_hit_daemon.py`, which is responsible for creating labelling tasks if none exist. another useful one that you'll probably want to have running is `cleanup_absent_worker.py`, which is analogous to the task unlocker in Raster Foundry
- `getkml.wsgi` is the frontend and pulls in all of the visualization stuff from the `OL/` directory; the main goal of this work is to have `getkml.wsgi` running in the container; I'm not sure how to verify dependencies between this WSGI application  and the other two
- there's an authentication mechanism that doesn't currently have any kind of local setup; a local setup would be useful and might be a requirement for verifying that everything is working properly
- database connection is currently loaded from a special yaml file; the expectations about what's in that yaml file can be seen in `db_production_name`, etc. in the `MappingCommon.py` file. we can provide these instead via env variables. this will be useful for getting a database into a compose file that separates the database from the web server (there's an implicit goal here that there's a local dev environment; I was planning on using the `2.4-postgres9.6-slim` tag for `quay.io/azavea/postgis` for this, since it's a version that's available in RDS / Aurora and it's close to the Postgres version mentioned in the `build-labeller.md` file)
- infra choices are an artifact of trying to replicate in AWS the setup that existed on university internal infrastructure; if there's a service that makes things easier and helps uncouple a surprising infra choice, feel free to use it
- `crontab_runner.py` is responsible for handling the scheduled jobs; probably this can be handled in the background in the container somehow
- this application does a lot, and has a significantly more refined understanding of labeller scoring and validation than GroundWork has -- while bringing the app up, keep eyes peeled for useful things that we would be able to integrate
- a number of `R` scripts in the repository run on a schedule -- they don't need to be running to run the application at all, but they are useful for some kinds of intermittent tasks
- the frontend content is the `maintext` value in `api/getkml.wsgi`

## Current state

The GDAL version mentioned in `build-labeller.md` is a 2.x version. The oldest non-rc (non-cursed? I vaguely remember 2.4.x or 2.5.x being cursed) version available in the `osgeo/gdal` tag is 2.4.1. I'm calling that _pretty close_ and building from that alpine image, since it means not having to go through the "build GDAL" steps.

From there I'm trying to make sure all of the dependencies mentioned in `build-labeller.md` are available, and also those not mentioned but that happen to be present in various python modules. That's tough, because there's a convention in python projects is to pin the floor, then say "yeah anything after this." If "anything after this" includes several years of releases, the python version you're building on has reached end of life, and package managers don't correctly exclude lower versions from their published packages, you can get in trouble pretty quickly. I've dealt with most of that trouble I think (pandas / numpy / proj adventures were fun) but am running into some problems around SQLAlchemy and the Flask libs that aren't pinned. *This is the next step*.

To start the service, you can run `docker-compose up application`. This will throw errors at startup -- that's good! That's what to fix.

The next step after the application starts up without dependency problems (right now: `cannot import name MigrateCommand` 🤷🏻‍♂️) is to get connected to a database. That should probably use the `postgis` image mentioned above.

After that, we need to figure out how to lie about authentication for the development environment. This can either take the form of creating database records with a `load_development_data` kind of script, or with some kind of sign up flow via the available Flask plugins. The former is probably easier, given that we don't actually know Flask. You'll know this is done when you can figure out how to authenticate.

_after that_, I think the next step is getting the `OL/` directory mounted in in the correct place so we can see stuff. And then... declare victory? At least, show @ldemaz and see what he thinks. I think at that point the initial work will have produced an Actual Thing™️ that we can talk about to figure out where the most value is here and what we're missing.